### PR TITLE
Hell cannot attack soulless players

### DIFF
--- a/_info/channels/wager
+++ b/_info/channels/wager
@@ -2,7 +2,7 @@
 
 You can decide to either:
 
-1. Attack a player, but sell your soul <?Soul:> in the process.
+1. Attack a player who still has a soul, but sell your soul <?Soul:> in the process.
 
 2. Protect yourself or any player, but sell your soul <?Soul:> in the process.
 

--- a/other/hell/souls
+++ b/other/hell/souls
@@ -3,7 +3,7 @@ __Basics__
 Members of the hell team that can use Souls - soul users - may use a Soul to protect someone from all attacks for the current night. If used in this way during a day phase, the player will be protected during the following night phase.
 Using a Soul to protect a player is an immediate effect.
 
-Soul users may use a Soul to attack a player. The player will be attacked immediately. The method of their death is not revealed (except to coroners). 
+Soul users may use a Soul to attack a player. The player will be attacked immediately. If the attacked player is soulless or a part of the hell team, the attack fails. The method of their death is not revealed (except to coroners). 
 This ability may be used during both day and night phases.
 
 If a soul user is attacked during the night and there is a soul in the pool, the soul user will be protected and a soul will be used up automatically. A soul is used up for every attack against a soul user.
@@ -14,6 +14,7 @@ __Simplified__
 Members of the hell team can use Souls - soul users - may use a Soul to protect or attack another player. If a soul user is attacked during the night and there is an available soul, they will be automatically protected.
 
 __Formalized__
+OUTDATED - attack may not target hell/soulless
 Immediate: [Condition: #Hell->Counter > 0]
   • Protect @Selection from `Attacks` through Active Defense during Night (~NextNight)
   • Decrement Counter for #Hell 

--- a/other/hell/wager
+++ b/other/hell/wager
@@ -5,7 +5,7 @@ The Wager recipient may choose one of four options:
 1) The Wager recipient may choose to sell their soul in order to attack another player. 
 Selling the soul immediately adds it to the hell team's soul pool. The Wager recipient then becomes soulless. At the end of the night, the devil will attack the player chosen by the Wager recipient. If the Devil dies before the night ends, the attack is not executed.
 Once the Wager recipient has chosen this option, they may change the target of the attack, or they may choose to change their chosen option to a protection. They cannot otherwise revoke their choice of option.
-If the Wager recipient chooses to attack a member of the hell team, they will sell their soul as normal, but the devil will not execute the attack. The Wager recipient is not informed of this.
+If the Wager recipient chooses to attack a soulless player, they will sell their soul as normal, but the devil will not execute the attack. The Wager recipient is not informed of this.
 The Devil is, but the Wager recipient is not, informed of whether the attack fails or succeeds.
 
 2) The Wager recipient may choose to sell their soul in order to protect a player.


### PR DESCRIPTION
Stops soul kills and wager kills from affecting soulless players to encourage players to use wager actions