### PR TITLE
Mark deleted roles as archived

### DIFF
--- a/archive/spectral cupid
+++ b/archive/spectral cupid
@@ -1,4 +1,4 @@
-**Spectral Cupid** | Unaligned Align | Limited Transformation
+**Spectral Cupid** | Unaligned Align | Archived
 __Basics__
 The Spectral Cupid is a cupid that has been recruited onto the nightmare team.
 __Details__


### PR DESCRIPTION
some roles that are deleted are not correctly marked as archived
![image](https://github.com/WerewolvesRevamped/Werewolves-Roles/assets/24660095/2b75e012-6039-4bdb-bf64-59c58acacc2a)
