### PR TITLE
Fix for emergency targeting

### DIFF
--- a/extra/killing/fletchers customer
+++ b/extra/killing/fletchers customer
@@ -13,7 +13,7 @@ The Fletcher's Customer is an extra role that doesn't replace the player's curre
 
 __Formalized__
 Immediate: Target @Selection (Player) 
-Immediate: Target @Selection (Player) [Quantity: 1]
+On Action [Targeting]: Target @Selection (Player) [Quantity: 1]
 On Killed: [Condition: @Target exists]
   • Process: Attack @Target
   • Evaluate: @Result is `Success`: Reveal `Fletcher's Customer @Self killed @Target` to #story_time

--- a/other/flute/flute apprentice
+++ b/other/flute/flute apprentice
@@ -13,7 +13,7 @@ Additionally, the Flute Apprentice can redirect the abilities of enchanted playe
 __Formalized__
 Starting: Join #Flutes
 Immediate: Target @Selection (Player) 
-Immediate: Target @Selection (Player) [Quantity: 1]
+On Action [Targeting]: Target @Selection (Player) [Quantity: 1]
 Passive: Redirect `all` from @(Attr:Enchanted) to @Target [Condition: @Target exists]
 On Action [Redirecting]: Learn `An ability was redirected`
 Passive: not (@(Role:Flute Player) exists): Role Change @Self to `Flute Player`

--- a/townsfolk/killing/executioner
+++ b/townsfolk/killing/executioner
@@ -12,7 +12,7 @@ After Day 1, whenever the Executioner is chosen to be lynched, it will be preven
 
 __Formalized__
 Immediate: Target @Selection (Player) 
-Immediate: Target @Selection (Player) [Quantity: 1]
+On Action [Targeting]: Target @Selection (Player) [Quantity: 1]
 Starting: Protect @Self from `Lynches` through Passive Defense (~UntilUse)
 On Passive Defense:
   • Process: Lynch @Target

--- a/townsfolk/killing/huntress
+++ b/townsfolk/killing/huntress
@@ -11,7 +11,7 @@ The Huntress may select a player to attack with their dying breath.
 
 __Formalized__
 Immediate: Target @Selection (Player) 
-Immediate: Target @Selection (Player) [Quantity: 1]
+On Action [Targeting]: Target @Selection (Player) [Quantity: 1]
 On Killed: [Condition: @Target exists]
   • Process: Attack @Target
   • Evaluate: @Result is `Success`: Reveal `Huntress @Self killed @Target` to #story_time

--- a/townsfolk/miscellaneous/assistant
+++ b/townsfolk/miscellaneous/assistant
@@ -12,7 +12,7 @@ They will be informed when their ability is used.
 
 __Formalized__
 Immediate: Target @Selection (Player) 
-Immediate: Target @Selection (Player) [Quantity: 1]
+On Action [Targeting]: Target @Selection (Player) [Quantity: 1]
 Passive: Redirect `non-killing abilities` from @(Attr:Wolfish) to @Target [Quantity: 1, Condition: @Target exists]
 On Action [Redirecting]: Learn `Redirect was used`
 

--- a/townsfolk/miscellaneous/journalist
+++ b/townsfolk/miscellaneous/journalist
@@ -13,7 +13,7 @@ The Journalist can write a journal which a player with a role of their choice wi
 __Formalized__
 Starting: Starting: Grant `Journal Holder` to @Self
 Immediate: Target @Selection (Role)
-Immediate: Target @Selection (Role) [Quantity: 1]
+On Action [Targeting]: Target @Selection (Role) [Quantity: 1]
 On Death: [Condition: @Target exists]
   • Target randomize(@(Role:@Target))
   • Transfer `Journal Holder` from @Self to @Target

--- a/townsfolk/miscellaneous/ranger
+++ b/townsfolk/miscellaneous/ranger
@@ -12,7 +12,7 @@ The Ranger may select a player to reveal with their dying breath. Both their tar
 
 __Formalized__
 Immediate: Target @Selection (Player) 
-Immediate: Target @Selection (Player) [Quantity: 1]
+On Action [Targeting]: Target @Selection (Player) [Quantity: 1]
 On Killed: [Condition: @Target exists]
   • Process: Role Investigate @Target (SD)
   • Evaluation: Reveal `Ranger @Self reveals @Target as @Result` to #story_time

--- a/unaligned/investigative/psychopath
+++ b/unaligned/investigative/psychopath
@@ -31,7 +31,7 @@ Passive:
   • not (@(Attr:PsychopathList:@Self) exists): 
     ‣ Ascend
 Immediate: Strongly Disguise @Self as @Selection
-Immediate: Strongly Disguise @Self as @Selection [Quantity: 1]
+On Action [Disguising]: Strongly Disguise @Self as @Selection [Quantity: 1]
 Passive Start Day: `Psychopath` Choice Creation:
   • `Investigate`:
     ‣ Role Investigate @Selection (WD, SD)

--- a/unaligned/killing/angel
+++ b/unaligned/killing/angel
@@ -13,8 +13,8 @@ The Angel wins when they are lynched: the game continues afterwards. In addition
 The Angel may select a player that dies when the Angel is lynched, but only if the target is voting for the Angel. 
 
 __Formalized__
-Immediate: Target @Selection (Player) [Condition: @Selection is not @Self]
-Immediate: Target @Selection (Player) [Condition: @Selection is not @Self, Quantity: 1]
+Immediate: Target @Selection (Player)
+On Action [Targeting]: Target @Selection (Player) [Quantity: 1]
 On Lynch:
   • (@OtherVoters exists) or (@Attacker exists): 
     ‣ @Attacker exists: Target @Attacker (Player)


### PR DESCRIPTION
The way emergency targeting is setup you get 2 prompts at the start of every phase. With this fix the emergency targetting prompt is only triggered by the main targeting being used