### PR TITLE
Continue ability type for P/E (Needed by Exorcist)

### DIFF
--- a/Formalization Guide.md
+++ b/Formalization Guide.md
@@ -452,6 +452,8 @@ As a first step all the abilities from the process step are evaluated, and their
 Afterwards, each evaluate line is evaluated.
 Each line consists of a `<Condition>`, or `Otherwise`. `Otherwise` triggers only if none of the other conditions trigger. Only a single conditions may trigger, further conditions are not evaluated.
 
+When using `Continue` as the last ability of a condition with several abilities attached, the evaluation of conditions will __continue__ instead of being halted as usual.
+
 In some cases it is useful to use evaluate without any conditions. In this case all evaluate lines without a condition should be put before any conditions, and they will always be executed. If no condition is specified at all, the default behaivor is to return no feedback at all as usually the feedback of the succeeding condition is returned. This can be worked around by specifying a `Feedback: <Ability>` line (this is equal in effect to specifying a single `Otherwise` line, but sounds more appropriate).
 
 If only a single condition line with feedback "Success" is provided, an `Otherwise: Failure` line is implied.

--- a/townsfolk/power/exorcist
+++ b/townsfolk/power/exorcist
@@ -27,30 +27,32 @@ Immediate Day: [Attribute: @Selection lacks `Exorcised:Self`]
     ‣ Remove `Powdered` from @Selection
     ‣ Remove `Demonized` from @Selection
     ‣ Remove `Contaminated` from @Selection
-    ‣ Remove `Sleepless` from @Selection
     ‣ Remove `Doomed` from @Selection
   • Evaluate:
     ‣ @Result1 is `Success`:
       ◦ Reveal `@Selection was cured of Enchanted` to @(Align:Flute)
       ◦ Learn `@Selection was cured of Enchanted`
+      ◦ Continue
     ‣ @Result2 is `Success`:
       ◦ Reveal `@Selection was cured of Charmed` to @(Align:Flute)
       ◦ Learn `@Selection was cured of Charmed`
+      ◦ Continue
     ‣ @Result3 is `Success`:
       ◦ Reveal `@Selection was cured of Powdered` to @(Align:Pyro)
       ◦ Learn `@Selection was cured of Powdered`
+      ◦ Continue
     ‣ @Result4 is `Success`:
       ◦ Reveal `@Selection was cured of Demonized` to @(Align:Underworld)
       ◦ Learn `@Selection was cured of Demonized`
+      ◦ Continue
     ‣ @Result5 is `Success`:
       ◦ Reveal `@Selection was cured of Contaminated` to @(Align:Plague)
       ◦ Learn `@Selection was cured of Contaminated`
+      ◦ Continue
     ‣ @Result6 is `Success`:
-      ◦ Reveal `@Selection was cured of Sleepless` to @(Align:Nightmare)
-      ◦ Learn `@Selection was cured of Sleepless`
-    ‣ @Result7 is `Success`:
       ◦ Reveal `@Selection was cured of Doomed` to @(Align:Horsemen)
       ◦ Learn `@Selection was cured of Doomed`
+      ◦ Continue
 
 __Card__
 The Exorcist performs exorcisms on the villagers who think they've been possesed.


### PR DESCRIPTION
Adding "Continue" as an ability that may be used in P/E to continue evaluating conditions

Used by Exorcist