### PR TITLE
Plague changes

### DIFF
--- a/_game/teams/Plague
+++ b/_game/teams/Plague
@@ -7,4 +7,7 @@ Win Condition: @(Alignment:Plague), @(Class:Unaligned)
 On Join: Add @Joiner to #Plague-Pit
 Passive Start Phase:
   • Process: Investigate @(Attr:Contaminated) Player Count
-  • Evaluate: Reveal `@Result Players have the Plague` to #plague-pit
+  • Evaluate: 
+    ‣ @Result->Number is `0`: Reveal `No one has the Plague` to #plague-pit
+    ‣ @Result->Number is `1`: Reveal `@Result->Number Player has the Plague` to #plague-pit
+    ‣ Otherwise: Reveal `@Result->Number Players have the Plague` to #plague-pit

--- a/_game/teams/Plague
+++ b/_game/teams/Plague
@@ -5,3 +5,4 @@ Plague Team wins when all players are either dead, unaligned or part of the Plag
 __Formalized__
 Win Condition: @(Alignment:Plague), @(Class:Unaligned)
 On Join: Add @Joiner to #Plague-Pit
+Passive Start Phase: Investigate @(Attr:Contaminated) Player Count

--- a/_game/teams/Plague
+++ b/_game/teams/Plague
@@ -5,4 +5,6 @@ Plague Team wins when all players are either dead, unaligned or part of the Plag
 __Formalized__
 Win Condition: @(Alignment:Plague), @(Class:Unaligned)
 On Join: Add @Joiner to #Plague-Pit
-Passive Start Phase: Investigate @(Attr:Contaminated) Player Count
+Passive Start Phase:
+  • Process: Investigate @(Attr:Contaminated) Player Count
+  • Evaluate: Reveal `@Result Players have the Plague` to #plague-pit

--- a/_game/teams/Plague
+++ b/_game/teams/Plague
@@ -9,5 +9,5 @@ Passive Start Phase:
   • Process: Investigate @(Attr:Contaminated) Player Count
   • Evaluate: 
     ‣ @Result is 0: Reveal `No one has the Plague` to #plague-pit
-    ‣ @Result is 1: Reveal `@Result->Number Player has the Plague` to #plague-pit
-    ‣ Otherwise: Reveal `@Result->Number Players have the Plague` to #plague-pit
+    ‣ @Result is 1: Reveal `@Result->Number player has the Plague` to #plague-pit
+    ‣ Otherwise: Reveal `@Result->Number players have the Plague` to #plague-pit

--- a/_game/teams/Plague
+++ b/_game/teams/Plague
@@ -8,6 +8,6 @@ On Join: Add @Joiner to #Plague-Pit
 Passive Start Phase:
   • Process: Investigate @(Attr:Contaminated) Player Count
   • Evaluate: 
-    ‣ @Result->Number is `0`: Reveal `No one has the Plague` to #plague-pit
-    ‣ @Result->Number is `1`: Reveal `@Result->Number Player has the Plague` to #plague-pit
+    ‣ @Result is 0: Reveal `No one has the Plague` to #plague-pit
+    ‣ @Result is 1: Reveal `@Result->Number Player has the Plague` to #plague-pit
     ‣ Otherwise: Reveal `@Result->Number Players have the Plague` to #plague-pit

--- a/other/plague/plague bearer
+++ b/other/plague/plague bearer
@@ -11,6 +11,7 @@ At the start of the second night after being contaminated, the player is informe
 At the end of the second night after being contaminated, the player will die. This is not an attack. Should the player still be alive afterwards, they remain contaminated, and will die at the end of the next night.
 If no members of the plague team or channel remain, all players stop being contaminated: they are not informed of this.
 If the Plague Bearer attempts to use a rodent on the Plague Doctor, the attempt fails, the Plague Doctor immediately dies (this is not an attack), and the rodent is *not* used up.
+At the start of every phase, members of the plague team are told the amount of living contaminated players.
 
 __Simplified__
 Each night, the Plague Bearer may send a rodent to a player to give them the plague.

--- a/other/plague/plague carrier
+++ b/other/plague/plague carrier
@@ -17,6 +17,9 @@ At the start of every night, the Plague Carrier is told the roles of players who
 __Formalized__
 Starting: Apply `Contaminated` to @Self (~Persistent) (EarlyStage, $phase)
 Passive: Role Change @Self to `Plague Bearer` [Condition: (not (@(Role:Plague-Bearer) exists)) and (#Plague-Pit->Counter > 0)]
+Passive End Day: For Each @(Attr:Contaminated): @Ind->Attr(Contaminated)->Value1 is `MiddleStage`: Learn `A @Ind->Role is going to die of the plague`
+
+Investigate @(Attr:Contaminated) Player Count
 
 __Card__
 The Plague Carrier is the sickly sidekick of the plague bearer.

--- a/other/plague/plague carrier
+++ b/other/plague/plague carrier
@@ -17,7 +17,10 @@ At the start of every night, the Plague Carrier is told the roles of players who
 __Formalized__
 Starting: Apply `Contaminated` to @Self (~Persistent) (EarlyStage, $phase)
 Passive: Role Change @Self to `Plague Bearer` [Condition: (not (@(Role:Plague-Bearer) exists)) and (#Plague-Pit->Counter > 0)]
-Passive End Day: For Each @(Attr:Contaminated): @Ind->Attr(Contaminated)->Value1 is `MiddleStage`: Learn `A @Ind->Role is going to die of the plague`
+Passive End Day: 
+  • For Each @(Attr:Contaminated):
+    ‣ @Ind->Attr(Contaminated)->Value1 is `MiddleStage`:
+      ◦ Learn `A @Ind->Role is going to die of the plague`
 
 __Card__
 The Plague Carrier is the sickly sidekick of the plague bearer.

--- a/other/plague/plague carrier
+++ b/other/plague/plague carrier
@@ -1,10 +1,9 @@
 **Plague Carrier** | Solo Miscellaneous - Plague Team
 __Basics__ 
-The Plague Carrier learns which roles will die to the plague.
+The Plague Carrier learns the roles of players who will die to the plague.
 __Details__
-At the start of each night, the Plague Carrier will learn the roles of the players destined to die to the plague at the end of that night. The Plague Carrier does not learn which player has which role. 
+At the start of each night, the Plague Carrier will learn the roles of the players who will die to the plague at the end of that night. The Plague Carrier does not learn which player has which role. 
 If more than one player with the same role would die, the Plague Carrier learns that role multiple times.
-If somebody tries to copy a plague bearer, a Plague Carrier is created instead. 
 The Plague Carrier starts out contaminated, but will never die due to the plague.
 A plague bearer may not attempt to directly contaminate the Plague Carrier using one of their rodents.
 If the last plague bearer dies, and there are rodents remaining, the Plague Carrier stops being contaminated and becomes a plague bearer.

--- a/other/plague/plague carrier
+++ b/other/plague/plague carrier
@@ -19,7 +19,5 @@ Starting: Apply `Contaminated` to @Self (~Persistent) (EarlyStage, $phase)
 Passive: Role Change @Self to `Plague Bearer` [Condition: (not (@(Role:Plague-Bearer) exists)) and (#Plague-Pit->Counter > 0)]
 Passive End Day: For Each @(Attr:Contaminated): @Ind->Attr(Contaminated)->Value1 is `MiddleStage`: Learn `A @Ind->Role is going to die of the plague`
 
-Investigate @(Attr:Contaminated) Player Count
-
 __Card__
 The Plague Carrier is the sickly sidekick of the plague bearer.

--- a/other/plague/plague carrier
+++ b/other/plague/plague carrier
@@ -1,16 +1,18 @@
 **Plague Carrier** | Solo Miscellaneous - Plague Team
 __Basics__ 
-The Plague Carrier wins with the plague bearers and joins a channel with them to communicate securely.
+The Plague Carrier learns which roles will die to the plague.
 __Details__
-The Plague Carrier does not have any special abilities. If somebody tries to copy a plague bearer, a Plague Carrier is created instead. 
+At the start of each night, the Plague Carrier will learn the roles of the players destined to die to the plague at the end of that night. The Plague Carrier does not learn which player has which role. 
+If more than one player with the same role would die, the Plague Carrier learns that role multiple times.
+If somebody tries to copy a plague bearer, a Plague Carrier is created instead. 
 The Plague Carrier starts out contaminated, but will never die due to the plague.
 A plague bearer may not attempt to directly contaminate the Plague Carrier using one of their rodents.
-If the last plague bearer dies, and there are rodents left, the Plague Carrier stops being contaminated and becomes a plague bearer.
-At the start of every phase, the Plague Carrier is told the amount of living contaminated players.
+If the last plague bearer dies, and there are rodents remaining, the Plague Carrier stops being contaminated and becomes a plague bearer.
+At the start of every phase, members of the plague team are told the amount of living contaminated players.
 
 __Simplified__
 The Plague Carrier wins with the plague bearers and joins a channel with them. The Plague Carrier is a carrier of the plague, but can't die from it.
-At the start of every phase, the Plague Carrier is told the amount of living contaminated players.
+At the start of every night, the Plague Carrier is told the roles of players who will die from the plague that night.
 
 __Formalized__
 Starting: Apply `Contaminated` to @Self (~Persistent) (EarlyStage, $phase)

--- a/other/plague/plague carrier
+++ b/other/plague/plague carrier
@@ -16,7 +16,6 @@ At the start of every night, the Plague Carrier is told the roles of players who
 
 __Formalized__
 Starting: Apply `Contaminated` to @Self (~Persistent) (EarlyStage, $phase)
-Passive Start Phase: Investigate @(Attr:Contaminated) Player Count
 Passive: Role Change @Self to `Plague Bearer` [Condition: (not (@(Role:Plague-Bearer) exists)) and (#Plague-Pit->Counter > 0)]
 
 __Card__


### PR DESCRIPTION
Changes:
- Added new PC ability, learning roles of those who will die to plague that night
- Added knowledge of active contaminations to PB, and rephrased it in PC description to refer to "members of the plague team"

Editorial decision:
- Specified that if multiple of the same role would die, that role is learnt multiple times